### PR TITLE
fix the build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^travis_setup\.sh$
 ^appveyor\.yml$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: R
-sudo: false
+sudo: required
 cache: packages
 warnings_are_errors: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,19 @@ bioc_packages:
   - ComplexHeatmap
   - biomaRt
   
+env:
+  global:
+    - _R_CHECK_TIMINGS_=0
+    - _R_CHECK_FORCE_SUGGESTS_=FALSE
+    - ASAN="-fsanitize=address -fno-omit-frame-pointer"
+    - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    - HDF5_VERSION=1.8.17
+    - HDF5_RELEASE_URL="https://support.hdfgroup.org/ftp/HDF5/releases"
+
+before_install: 
+  - chmod +x travis_setup.sh
+  - ./travis_setup.sh
+  
 before_deploy: Rscript -e 'install.packages("pkgdown")'
 
 deploy:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,6 @@ VignetteBuilder: knitr
 Encoding: UTF-8
 LazyData: true
 Remotes: 
-    stephlocke/datasauRus,
-    UCSF-TI/fake-hdf5r
+    stephlocke/datasauRus
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,6 +49,8 @@ Suggests:
 VignetteBuilder: knitr
 Encoding: UTF-8
 LazyData: true
-Remotes: stephlocke/datasauRus
+Remotes: 
+    stephlocke/datasauRus,
+    UCSF-TI/fake-hdf5r
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@ on_failure:
 environment:
   global:
     USE_RTOOLS: true 
-    WARNINGS_ARE_ERRORS: 0
     _R_CHECK_FORCE_SUGGESTS_: false
     
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,9 @@ on_failure:
 environment:
   global:
     USE_RTOOLS: true 
-
+    WARNINGS_ARE_ERRORS: 0
+    _R_CHECK_FORCE_SUGGESTS_: false
+    
 artifacts:
   - path: '*.Rcheck\**\*.log'
     name: Logs

--- a/travis_setup.sh
+++ b/travis_setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "$TRAVIS_OS_NAME" != "osx" ]; then #
+  cd ..
+  wget "$HDF5_RELEASE_URL/hdf5-${HDF5_VERSION%.*}/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.gz"
+  tar -xzf "hdf5-$HDF5_VERSION.tar.gz"
+  cd "hdf5-$HDF5_VERSION"
+  ./configure --prefix=/usr/local
+  sudo make install
+  cd ../seurat
+fi

--- a/travis_setup.sh
+++ b/travis_setup.sh
@@ -7,5 +7,4 @@ if [ "$TRAVIS_OS_NAME" != "osx" ]; then #
   cd "hdf5-$HDF5_VERSION"
   ./configure --prefix=/usr/local
   sudo make install
-  cd ../seurat
 fi

--- a/vignettes/class-6.Rmd
+++ b/vignettes/class-6.Rmd
@@ -140,11 +140,11 @@ length(x = pbmc@var.genes)
 
 Single cell data sets contain various types of 'uninteresting' variation. These can include technical noise, batch effects and confounding biological variation (such as cell cycle stage). We can regress these signals out of the analysis using ` ScaleData`.
 
-```{r regress, eval=FALSE}
+```{r regress}
 pbmc <- ScaleData(object = pbmc,
                   vars.to.regress = c("nUMI", "percent.mito"))
 ```
-```{r echo=F}
+```{r echo=F, eval = F}
 pbmc <- readRDS("/Users/austingillen/source/eda/regressed_seurat.rds")
 ```
 ## Performing dimensionality reduction and clustering: PCA

--- a/vignettes/class-6.Rmd
+++ b/vignettes/class-6.Rmd
@@ -229,7 +229,7 @@ pbmc.markers <- FindAllMarkers(object = pbmc,
 
 pbmc.markers %>%
   group_by(cluster) %>%
-  top_n(2, avg_diff)
+  top_n(2, avg_logFC)
 
 ```
 


### PR DESCRIPTION
Seurat depends on hdf5r which doesn't build on travis. This dependency is only used by the `read_10x_h5()` function. There is a fake hdfr5 package that should allow users to build seurat without the hdf5r dependency. 

See workaround here: https://github.com/satijalab/seurat/issues/622
